### PR TITLE
Update Dockerfile for audiowaveform 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 from alpine:latest
-env commit 7c38d99
+env tag 1.5.0
 run apk update && \
  apk add --virtual build-dependencies cmake curl git jq make && \
  apk add boost-dev g++ gcc gd-dev libid3tag-dev libmad-dev libsndfile-dev && \
  git clone -n https://github.com/bbc/audiowaveform.git && \
  cd audiowaveform && \
- git checkout ${commit} && \
+ git checkout ${tag} && \
  curl -fL# $(curl -s "https://api.github.com/repos/google/googletest/releases/latest" | jq -r .tarball_url) -o googletest.tar.gz && \
- tar -xf googletest.tar.gz && \
- ln -s google*/google* . && \
+ mkdir googletest && \
+ tar -xf googletest.tar.gz -C googletest --strip-components=1 && \
  mkdir build && \
  cd build && \
  cmake .. && \


### PR DESCRIPTION
This change fixes googletest installation.

It also uses a tag to set the audiowaveform version (tagged releases are stable, whereas master may not be).