### PR TITLE
fix flac build by installing gettext-dev on alpine edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache cmake g++ gcc git samurai && \
 	cmake --build build -j $(nproc) && \
 	ctest -j $(nproc) && \
 	cmake --install build
-RUN apk add --no-cache autoconf automake libtool g++ gcc gettext git !libiconv make pkgconfig && \
+RUN apk add --no-cache autoconf automake libtool g++ gcc gettext-dev git !libiconv make pkgconfig && \
 	git clone https://github.com/xiph/flac && \
 	cd flac && \
 	./autogen.sh && \


### PR DESCRIPTION
## Summary
- All 7 platform builds have been failing since 2026-05-18 at the FLAC step.
- Alpine `edge` moved `/usr/share/gettext/archive.dir.tar.xz` from the `gettext` package into `gettext-dev`. FLAC's `autogen.sh` runs `autopoint`, which needs that archive to extract infrastructure for the gettext version pinned in FLAC's `configure.ac` (`0.23.1`). Without it, `autoreconf` aborts and `make install` has no Makefile.
- Swap `gettext` → `gettext-dev` on the FLAC step only. The opus step also installs `gettext` but its `autogen.sh` doesn't invoke `autopoint`, so it's unaffected.

The failing log line on every platform:
```
/usr/bin/autopoint: line 533: can't open /usr/share/gettext/archive.dir.tar.xz: no such file
autopoint: *** infrastructure files for version 0.23.1 not found
```

## Test plan
- [x] Reproduced locally in `alpine:edge`: with `gettext` alone, `./autogen.sh` fails with the same error; with `gettext-dev`, it completes.
- [x] Verified the `gettext-dev` archive contains `gettext-0.23.1` (alongside 0.22.x, 0.24.x, 0.25.x, 0.26, 1.0).
- [ ] Workflow green on all 7 platforms once merged (or via `workflow_dispatch` on this branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker builder stage dependencies for optimized image configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/audiowaveform-docker/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->