### PR TITLE
bump github actions to node 24 runtimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       tags: ${{ steps.prepare_tags.outputs.tags }}
     steps:
       - name: Checkout audiowaveform-docker repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'realies/audiowaveform-docker'
           path: 'audiowaveform-docker'
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Dockerfile
         if: steps.check.outputs.should_build == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dockerfile
           path: audiowaveform-docker/Dockerfile
@@ -102,23 +102,23 @@ jobs:
           - linux/s390x
     steps:
       - name: Checkout audiowaveform-docker repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'realies/audiowaveform-docker'
 
       - name: Download Dockerfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dockerfile
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -146,7 +146,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ steps.platform_tag.outputs.tag }}
           path: /tmp/digests/*
@@ -158,17 +158,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -195,13 +195,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout audiowaveform-docker repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'realies/audiowaveform-docker'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Dockerfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dockerfile
 


### PR DESCRIPTION
## Summary
Node.js 20 is deprecated on GitHub-hosted runners. Per the [Sept 2025 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 24 becomes the forced default on **June 2nd, 2026** and Node 20 is removed entirely on **September 16th, 2026**. Every action this workflow uses currently runs on Node 20, generating deprecation warnings on each scheduled build.

This PR bumps all seven actions to their latest majors, which run on Node 24:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `docker/build-push-action` | v5 | v7 |
| `docker/login-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |

## Breaking changes considered (none apply here)
- **`download-artifact` v5**: changed the output path for single-artifact downloads by *ID*. We use `name:` and `pattern:` lookups, so unaffected.
- **`build-push-action` v7**: removed `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs and the legacy export-build tool. We don't set any of these.
- **`upload-artifact` v7**: adds opt-in `archive: false` for direct uploads. Default behavior preserved.
- All majors require runner ≥ `v2.327.1` (or `v2.329.0` for `checkout@v6`). GitHub-hosted runners are well past these.

## Test plan
- [x] Skimmed release notes for every major between current and target.
- [x] Verified no removed envs, removed inputs, or path-format changes hit this workflow.
- [ ] Verify with `gh workflow run` against this branch (or merge and watch the next scheduled run).